### PR TITLE
Upgrade Hugo workflow with latest versions

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.111.3
+      HUGO_VERSION: 0.132.2
     steps:
       - name: Install Hugo CLI
         run: |
@@ -41,13 +41,13 @@ jobs:
       - name: Install Dart Sass Embedded
         run: sudo snap install dart-sass-embedded
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
@@ -61,7 +61,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"          
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 
@@ -75,4 +75,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and deploying the Hugo site. The main changes are version bumps for Hugo and several GitHub Actions to ensure compatibility and take advantage of the latest features and security improvements.

**Workflow dependency updates:**

* Upgraded the `HUGO_VERSION` environment variable from `0.111.3` to `0.132.2` for the latest Hugo release.

* Updated the following GitHub Actions to their latest major versions:
  - `actions/checkout` from v3 to v4
  - `actions/configure-pages` from v3 to v4
  - `actions/upload-pages-artifact` from v1 to v3
  - `actions/deploy-pages` from v2 to v4